### PR TITLE
fix(talks): URLs buttons logic

### DIFF
--- a/al_folio_theme/templates/_includes/talk_entries.html
+++ b/al_folio_theme/templates/_includes/talk_entries.html
@@ -20,11 +20,11 @@
             <div class="links">  
               {%- for field in entry.buttons -%}
                 {% set link = entry.buttons[field] -%}
-                {% set relative = "://" in link %}
-                {% if not relative -%}
-                <a href="{{ link }}" class="btn btn-sm z-depth-0" role="button">{{ field | capitalize}}</a>
-                {%- else -%}
+                {% set relative = "://" not in link %}
+                {%- if relative -%}
                 <a href="{{ link | relative_url }}" class="btn btn-sm z-depth-0" role="button">{{field | capitalize}}</a>
+                {%- else -%}
+                <a href="{{ link }}" class="btn btn-sm z-depth-0" role="button">{{ field | capitalize}}</a>
                 {%- endif %}
               {%- endfor %}
             </div>


### PR DESCRIPTION
I have a bug on talk pages buttons in which the URLs were relative to my URL site. I adjusted the logic to be clearer and to solve this problem